### PR TITLE
fix: make conflicting PRs draft

### DIFF
--- a/backport/backport.js
+++ b/backport/backport.js
@@ -43,13 +43,15 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
     const git = async (...args) => {
         await exec_1.exec('git', args, { cwd: repo });
     };
+    let isDraft = false;
     await git('switch', base);
     await git('switch', '--create', head);
     try {
         await git('cherry-pick', '-x', commitToBackport);
     }
     catch (error) {
-        body += "⚠️  CONFLICTS detected ⚠️  \n";
+        isDraft = true;
+        body += "\n\n ⚠️  CONFLICTS detected ⚠️  \n";
         body += "Please resolve conflicts and verify diff with original PR before merging.";
         await git('add', '*'); // YOLO
         await git('commit', '-a', '--no-edit', '--allow-empty');
@@ -62,6 +64,7 @@ const backportOnce = async ({ base, body, commitToBackport, github, head, labels
         owner,
         repo,
         title,
+        draft: isDraft,
     });
 };
 const getFailedBackportCommentBody = ({ base, commitToBackport, errorMessage, head, }) => {

--- a/backport/backport.ts
+++ b/backport/backport.ts
@@ -101,13 +101,16 @@ const backportOnce = async ({
 		await exec('git', args, { cwd: repo })
 	}
 
+	let isDraft = false;
+
 	await git('switch', base)
 	await git('switch', '--create', head)
 	try {
 		await git('cherry-pick', '-x', commitToBackport)
 	} catch (error) {
-                body += "⚠️  CONFLICTS detected ⚠️  \n"
-                body += "Please resolve conflicts and verify diff with original PR before merging."
+		isDraft = true;
+		body += "\n\n ⚠️  CONFLICTS detected ⚠️  \n"
+		body += "Please resolve conflicts and verify diff with original PR before merging."
 		await git('add', '*') // YOLO
 		await git('commit', '-a', '--no-edit', '--allow-empty')
 	}
@@ -120,6 +123,7 @@ const backportOnce = async ({
 		owner,
 		repo,
 		title,
+		draft: isDraft,
 	})
 }
 


### PR DESCRIPTION
To avoid chances of accidental merging, make PRs with conflicts draft by default. 